### PR TITLE
Updates for newer Symfony. Add basic tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor/
+/.idea/

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "BSD-2-Clause",
     "require": {
-        "symfony/process": "^2.0 || ^3.0 || ^4.0"
+        "symfony/process": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
         "psr-4": {
             "ProcessHelper\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4" : {
+            "ProcessHelper\\Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/bootstrap.php"
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="ProcessHelper TestSuite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/scripts/test-symfony.sh
+++ b/scripts/test-symfony.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+## usage: bash scripts/test-symfony.sh <VERSION_CONSTRAINTS...>
+## example: bash scripts/test-symfony.sh ^3.0 ^4.0 ^5.0
+
+{
+  set -e
+
+  for VER in "$@" ; do
+    git checkout -- composer.json
+    echo >&2
+    echo >&2 "======================================================"
+    echo >&2 "== Test symfony/process ($VER)"
+    echo >&2
+    composer require symfony/process:"$VER"
+    phpunit9
+  done
+
+  git checkout -- composer.json
+}

--- a/src/ProcessHelper.php
+++ b/src/ProcessHelper.php
@@ -101,7 +101,7 @@ class ProcessHelper {
       return $expr;
     }
     else {
-      return preg_replace_callback('/([#!@])([a-zA-Z0-9_]+)/', function($m) use ($args) {
+      return preg_replace_callback('/([#!@])([a-zA-Z0-9_]+)/', function ($m) use ($args) {
         if (isset($args[$m[2]])) {
           $values = $args[$m[2]];
         }
@@ -146,13 +146,25 @@ class ProcessHelper {
     if ($process instanceof Process) {
       return $process;
     }
+
+    if (is_callable([Process::class, 'fromShellCommandline'])) {
+      $newProcess = function ($cmd) {
+        return Process::fromShellCommandline($cmd, NULL, NULL, NULL, NULL);
+      };
+    }
+    else {
+      $newProcess = function ($cmd) {
+        return new Process($cmd, NULL, NULL, NULL, NULL);
+      };
+    }
+
     if (is_string($process)) {
-      return new Process($process, NULL, NULL, NULL, NULL);
+      return $newProcess($process);
     }
     if (is_array($process)) {
       $cmd = $process[0];
       unset($process[0]);
-      return new Process(self::interpolate($cmd, $process), NULL, NULL, NULL, NULL);
+      return $newProcess(self::interpolate($cmd, $process));
     }
     throw new \RuntimeException("Cannot cast item to process");
   }

--- a/tests/ProcessHelperTest.php
+++ b/tests/ProcessHelperTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ProcessHelper\Tests;
+
+use ProcessHelper\ProcessErrorException;
+use ProcessHelper\ProcessHelper as PH;
+
+class ProcessHelperTest extends \PHPUnit\Framework\TestCase {
+
+  public function testRunOk_arrayInput(): void {
+    $p = PH::runOk(['echo BEGIN @MSG END', 'MSG' => 'This -n and -t that.']);
+    $lines = explode("\n", $p->getOutput());
+    $this->assertEquals('BEGIN This -n and -t that. END', $lines[0]);
+
+    $report = PH::createReport($p);
+    $this->assertRegex(';COMMAND: echo BEGIN;', $report);
+    $cwd = preg_quote(getcwd(), ';');
+    $this->assertRegex(";CWD: $cwd;", $report);
+    $this->assertRegex(";EXIT CODE: 0;", $report);
+  }
+
+  public function testRunOk_stringInput(): void {
+    $p = PH::runOk('echo "Hello world"');
+    $this->assertTrue((bool) preg_match(';Hello world;', $p->getOutput()));
+  }
+
+  public function testRunOk_Fail_arrayInput(): void {
+    try {
+      PH::runOk(['echo Bad stuff ; exit @BADCODE', 'BADCODE' => 99]);
+    }
+    catch (ProcessErrorException $e) {
+      $this->assertEquals($e->getProcess()->getExitCode(), 99, "Exception should report exit code");
+      $this->assertRegex(';Bad stuff;', $e->getProcess()->getOutput());
+    }
+  }
+
+  public function testRunOk_Fail_stringInput(): void {
+    try {
+      PH::runOk('echo Bad stuff ; exit 98');
+    }
+    catch (ProcessErrorException $e) {
+      $this->assertEquals($e->getProcess()->getExitCode(), 98, "Exception should report exit code");
+      $this->assertRegex(';Bad stuff;', $e->getProcess()->getOutput());
+    }
+  }
+
+  public function testRun_Fail(): void {
+    $p = PH::run('echo Bad stuff ; exit 97');
+    $this->assertEquals($p->getExitCode(), 97, "Exception should report exit code");
+    $this->assertRegex(';Bad stuff;', $p->getOutput());
+  }
+
+  public function getInterpolateOK() {
+    $result = [];
+    $result[] = ['echo ABC', [], 'echo ABC'];
+    $result[] = ['echo @MSG', ['MSG' => 'Hello world'], 'echo \'Hello world\''];
+    $result[] = ['echo !MSG', ['MSG' => 'Hello world'], 'echo Hello world'];
+    $result[] = ['echo @MISSING', ['FOO' => 'bar'], 'echo @MISSING'];
+    return $result;
+  }
+
+  /**
+   * @param string $expr
+   * @param array $args
+   * @param string $expectOutput
+   * @return void
+   * @dataProvider getInterpolateOK
+   */
+  public function testInterpolateOK(string $expr, array $args, string $expectOutput) {
+    $output = PH::interpolate($expr, $args);
+    $this->assertEquals($expectOutput, $output, "Exception should report output");
+  }
+
+  public function getInterpolateFails() {
+    $result = [];
+    $result[] = ['echo #NUM', ['NUM' => 'abc'], ';Failed encoding non-numeric;'];
+    return $result;
+  }
+
+  /**
+   * @param string $expr
+   * @param array $args
+   * @param string $expectRegex
+   * @return void
+   * @dataProvider getInterpolateFails
+   */
+  public function testInterpolateFails(string $expr, array $args, string $expectRegex) {
+    try {
+      $executed = FALSE;
+      PH::interpolate($expr, $args);
+      $executed = TRUE;
+    }
+    catch (\RuntimeException $e) {
+      $this->assertRegex($expectRegex, $e->getMessage());
+    }
+    $this->assertFalse($executed, "Should have raised exception like: $expectRegex");
+
+  }
+
+  protected function assertRegex(string $regex, $value): void {
+    $msg = sprintf("Value (%s) should match regex (%s)", json_encode($value), json_encode($regex));
+    $this->assertTrue((bool) preg_match($regex, $value), $msg);
+  }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
To add support for Symfony 5+, one needs to address breaking-changes in how you construct the `Process` object.

I manually ran the test against a few versions of PHP and  Symfony Process:

```bash
## Tested in PHP 7.4
bash scripts/test-symfony.sh ^2.0 ^3.0 ^4.0 ^5.0

## Tested in PHP 8.2
bash scripts/test-symfony.sh ^5.0 ^6.0 ^7.0

## Tested in PHP 8.4
bash scripts/test-symfony.sh ^6.0 ^7.0
# (Tests passes, and I don't think there are any warnings from this library, but phpunit-cli may have warnings, depending on version.)
```

(Other variations probably work, but I just didn't test them.)
